### PR TITLE
Use most recent enum options

### DIFF
--- a/src/model_builder.py
+++ b/src/model_builder.py
@@ -114,7 +114,12 @@ def _set_type(param, data):
   param_type = next((key for key in domains if key in const.TYPES), False)
   if param_type == const.ENUM:
     param['ui'] = 'enum'
-    enum_list = data.get('domains', {}).get(const.ENUM, {}).get('enum_list', [])
+    enum = data.get('domains', {}).get(const.ENUM, {})
+    enum_list = enum.get('enum_list', [])
+    if all('v' in opt for opt in enum_list):
+      # For now use the most recent version if more than one listed
+      latest_version = list(enum_list.keys())[-1]
+      enum_list = enum.get('enum_list', [])[latest_version]
     param['domain'] = {val: val for val in enum_list}
   else:
     if param_type == const.BOOL:


### PR DESCRIPTION
In some cases there may be more than one list of options for enumerated values based on the version of ParFlow. Down the road this selection should be based on the version set by the user, but until that feature is added we will default to the most recent version listed.