### PR TITLE
Use more consistant naming patterns

### DIFF
--- a/src/templates.py
+++ b/src/templates.py
@@ -8,15 +8,20 @@ model = {
 }
 
 # Name Parameter
-name = {
-  'id': 'name',
-  'label': 'Name',
-  'size': 1,
-  'type': 'string'
-}
+def name_param(att_name):
+  param_id = att_name.split('/')[1]
+  param_id = param_id.replace('.{', '').replace('}', '')
+  name = [{
+    'id': f'{param_id}_',
+    'label': 'Name',
+    'size': 1,
+    'type': 'string'
+  }]
+
+  return name
 
 # Dynamic View Base
-def dyn_view(label, att_name):
+def dyn_view(att_name, label, param_id):
   view = {
     'label': label,
     'attributes': [att_name],
@@ -24,7 +29,7 @@ def dyn_view(label, att_name):
     'hooks': [
       {
         'type': 'copyParameterToViewName',
-        'attribute': f'{att_name}.name',
+        'attribute': f'{att_name}.{param_id}',
       }
     ]
   }


### PR DESCRIPTION
- Static view ids are named after the file they were created from
  - ex: geom.yaml > `Geom`
- Dynamic views ids are "parent key + _Properties"
  - ex: GeomInput/.{geom_input_name} > `GeomInput_Properties`
- Attributes are named from top-level keys for static views
  - ex: From geom.yaml Domain/ > `Domain`
- Dynamic views have a single attribute with the same name as the view
  - ex: for the view "GeomInput Properties" > `GeomInput_Properties`
- Dynamic property ids are a modified version of the original key
  - ex: .{geom_input_name} > `geom_input_name_`
- Parameter ids are composed of the entire path
  - ex: `GeomInput/geom_input_name_/InputType` or `Mannings/Type`

Goes with #6 to support a simplified conversion file